### PR TITLE
Fix: Correct syntax error in ApiKeyManager

### DIFF
--- a/frontend/src/components/api-keys/ApiKeyManager.tsx
+++ b/frontend/src/components/api-keys/ApiKeyManager.tsx
@@ -337,11 +337,6 @@ export function ApiKeyManager() {
               return acc;
             }, {} as Record<string, ApiKey[]>)
           ).map(([providerId, keys]) => (
-              acc[key.provider] = acc[key.provider] || [];
-              acc[key.provider].push(key);
-              return acc;
-            }, {} as Record<string, ApiKey[]>)
-          ).map(([providerId, keys]) => (
             <Card key={providerId} className="mb-4 bg-slate-800 border-slate-700 text-slate-100">
               <CardHeader className="flex flex-row items-center justify-between">
                 <div className="flex items-center gap-2">


### PR DESCRIPTION
The previous code had a duplicated and misplaced .map() call that was using a reduce-like callback, causing a syntax error during the build process: "Expected ) but found ;".

This commit removes the erroneous .map() block, ensuring that the API keys are correctly grouped by provider and then rendered using the intended .map() call that generates the JSX for each provider's card.